### PR TITLE
fix permission issues with storage directory

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -13,6 +13,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
     config.vm.provision :shell, :path => "install.sh"
 
+    config.vm.synced_folder ".", "/vagrant", :mount_options => ["dmode=777", "fmode=666"]
+
     # If true, then any SSH connections made will enable agent forwarding.
     # Default value: false
     # config.ssh.forward_agent = true


### PR DESCRIPTION
Laravel storage directory buggy at times with file permissions through shared Vagrant configuration.  Fix file permissions in vagrant configuration.
