### PR TITLE
Apache 000-default.conf points to /var/www/html -> but need /var/www

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -46,6 +46,7 @@ sed -i "s/error_reporting = .*/error_reporting = E_ALL/" /etc/php5/apache2/php.i
 sed -i "s/display_errors = .*/display_errors = On/" /etc/php5/apache2/php.ini
 
 sed -i 's/AllowOverride None/AllowOverride All/' /etc/apache2/apache2.conf
+sed -i 's/html//' /etc/apache2/sites-available/000-default.conf
 
 echo "--- Restarting Apache ---"
 sudo service apache2 restart


### PR DESCRIPTION
Not Found error by request of localhost:8080
Add line with search and replace to remove the html in this path.
Now the symlink is correct with the path /var/www
