### PR TITLE
Removed unnecessary sudos

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -3,39 +3,39 @@
 echo "--- Good morning, master. Let's get to work. Installing now. ---"
 
 echo "--- Updating packages list ---"
-sudo apt-get update
+apt-get update
 
 echo "--- MySQL time ---"
-sudo debconf-set-selections <<< 'mysql-server mysql-server/root_password password root'
-sudo debconf-set-selections <<< 'mysql-server mysql-server/root_password_again password root'
+debconf-set-selections <<< 'mysql-server mysql-server/root_password password root'
+debconf-set-selections <<< 'mysql-server mysql-server/root_password_again password root'
 
 echo "--- Installing base packages ---"
-sudo apt-get install -y vim curl python-software-properties
+apt-get install -y vim curl python-software-properties
 
 echo "--- We want the bleeding edge of PHP, right master? ---"
-sudo add-apt-repository -y ppa:ondrej/php5
+add-apt-repository -y ppa:ondrej/php5
 
 echo "--- Updating packages list ---"
-sudo apt-get update
+apt-get update
 
 echo "--- Installing PHP-specific packages ---"
-sudo apt-get install -y php5 apache2 libapache2-mod-php5 php5-curl php5-gd php5-mcrypt mysql-server-5.5 php5-mysql git-core
+apt-get install -y php5 apache2 libapache2-mod-php5 php5-curl php5-gd php5-mcrypt mysql-server-5.5 php5-mysql git-core
 
 echo "--- Installing and configuring Xdebug ---"
-sudo apt-get install -y php5-xdebug
+apt-get install -y php5-xdebug
 
-cat << EOF | sudo tee -a /etc/php5/mods-available/xdebug.ini
+cat << EOF | tee -a /etc/php5/mods-available/xdebug.ini
 xdebug.scream=1
 xdebug.cli_color=1
 xdebug.show_local_vars=1
 EOF
 
 echo "--- Enabling mod-rewrite ---"
-sudo a2enmod rewrite
+a2enmod rewrite
 
 echo "--- Setting document root ---"
-sudo rm -rf /var/www
-sudo ln -fs /vagrant/public /var/www
+rm -rf /var/www
+ln -fs /vagrant/public /var/www
 
 
 echo "--- What developer codes without errors turned on? Not you, master. ---"
@@ -45,11 +45,11 @@ sed -i "s/display_errors = .*/display_errors = On/" /etc/php5/apache2/php.ini
 sed -i 's/AllowOverride None/AllowOverride All/' /etc/apache2/apache2.conf
 
 echo "--- Restarting Apache ---"
-sudo service apache2 restart
+service apache2 restart
 
 echo "--- Composer is the future. But you knew that, did you master? Nice job. ---"
 curl -sS https://getcomposer.org/installer | php
-sudo mv composer.phar /usr/local/bin/composer
+mv composer.phar /usr/local/bin/composer
 
 # Laravel stuff here, if you want
 


### PR DESCRIPTION
Vagrant is already running install.sh as root, so the "sudo"s inside of it are unnecessary.

See:

http://docs.vagrantup.com/v2/provisioning/shell.html

Specifically, the "privileged" attribute, which in your Vagrantfile, is not set, and therefore defaulted to "true":

```
privileged (boolean) - Specifies whether to execute the shell script as a privileged user or not (sudo). By default this is "true".
```

And to be absolutely certain, you can add "whoami >> whoami.log" anywhere inside your install.sh script, and you can see it is "root".  This is likely how you're already able to modify your config files without sudo.

And thanks Jeffrey for all that you do... I'm a big fan.  :)
